### PR TITLE
Add Annotation Flag 'Locked' to make annotations immovable

### DIFF
--- a/attachfile2.dtx
+++ b/attachfile2.dtx
@@ -778,6 +778,11 @@ and the derived files
 \DeclareBoolOption[true]{zoom}
 %    \end{macrocode}
 %
+%    Option \xoption{lock}.
+%    \begin{macrocode}
+\DeclareBoolOption[true]{lock}
+%    \end{macrocode}
+%
 %    Option \xoption{appearance}.
 %    \begin{macrocode}
 \DeclareBoolOption[true]{appearance}
@@ -869,6 +874,7 @@ and the derived files
   timezone,%
   ucfilespec,%
   zoom,%
+  lock,%
 }
 %    \end{macrocode}
 %
@@ -1520,6 +1526,9 @@ and the derived files
   \ifatfi@zoom
   \else
     \addtocounter{atfi@flags}{8}%
+  \fi%
+  \ifatfi@lock
+  	\addtocounter{atfi@flags}{128}%
   \fi%
 }
 %    \end{macrocode}


### PR DESCRIPTION
This change is adding the option `lock`. It is opt-out, so enabled by default.
This will set the annotation flag 'Locked' (bit position 8).

Without this change, annotations can be moved around on the page.
This is the case in Acrobat Reader at least, and other readers just don't conform to the standard in this regard, I suppose.